### PR TITLE
Add explicit Context to track check in process

### DIFF
--- a/app/src/main/java/network/DataModel.kt
+++ b/app/src/main/java/network/DataModel.kt
@@ -7,4 +7,3 @@ data class CheckInResult(@SerializedName("status") val status: String)
 data class LogOutStatus(@SerializedName("logged_out") val loggedOut: Boolean)
 data class LocationEntity(@SerializedName("lat") val lat: Double, @SerializedName("lng") val lng: Double)
 data class LocationModel(@SerializedName("list") val list: List<LocationEntity>)
-

--- a/app/src/main/java/network/SingleApi.kt
+++ b/app/src/main/java/network/SingleApi.kt
@@ -17,7 +17,7 @@ interface SingleApi {
     fun logOut(): Single<LogOutStatus>
 
     @POST("check_in")
-    fun checkIn(@Header("token") flag: String, @Body model: LocationModel): Single<CheckInResult>
+    fun checkIn(@Tag context: Context? = null, @Body model: LocationModel, @Header("x-token") flag: String): Single<CheckInResult>
 
     @GET("check_out")
     fun checkoutWithoutBaggage(): Single<CheckInResult>


### PR DESCRIPTION
In this pull request and the following up pull request, I am to focus on exploring what's OpenTelemetry could do for us and how we should achieve it. 



Currently, this pull request implement a check-In process for employee. We could imagine that we are solving such use case:

1, When an employ arrives at the office, the employee opens the app and click the Check-In Button.
2, After the check-in button is clicked, the app will fetch the current device location.
3, After the device location is fetched, the app will send the fetch location to backend service. 
4, Then the UI will show Checked-In.



Based on the above use cases,  here is a list of business questions that stakeholders want to know:

1, How long does it takes from clicking the checkin button to location result ready?
2, How long does it takes process the network request?
3, Could we send the location information as context, rather than post body?

....



