### PR TITLE
Learned a new thing that onDestroy will not be called on tap back Button to Exit the app.

### DIFF
--- a/app/src/main/java/app/AppConstants.kt
+++ b/app/src/main/java/app/AppConstants.kt
@@ -1,5 +1,5 @@
 package app
 
 object AppConstants {
-    const val TAG_TEL = "utel_"
+    const val TAG_TEL = "logging"
 }

--- a/app/src/main/java/app/MainActivity.kt
+++ b/app/src/main/java/app/MainActivity.kt
@@ -8,6 +8,7 @@ import androidx.fragment.app.Fragment
 import com.chuckerteam.chucker.api.Chucker
 import com.example.hello_otel.R
 import repo.TokenStore
+import timber.log.Timber
 import ui.LoggedInFragment
 import ui.LoggedOutFragment
 
@@ -18,6 +19,7 @@ class MainActivity : AppCompatActivity(), LoggedInFragment.LoggedOutListener, Lo
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
         TracingUtil.endSpan()
+        Timber.tag(AppConstants.TAG_TEL).i("$this onCreate")
         if (TokenStore(AppContext.from(this)).isLoggedIn()) {
             bindLoggedInState()
         } else {
@@ -66,4 +68,30 @@ class MainActivity : AppCompatActivity(), LoggedInFragment.LoggedOutListener, Lo
         bindFragment(LoggedOutFragment())
     }
 
+    override fun onStart() {
+        super.onStart()
+        Timber.tag(AppConstants.TAG_TEL).i("$this onStart")
+
+    }
+
+    override fun onStop() {
+        super.onStop()
+        Timber.tag(AppConstants.TAG_TEL).i("$this onStop")
+
+    }
+
+    override fun onPause() {
+        super.onPause()
+        Timber.tag(AppConstants.TAG_TEL).i("$this onPause")
+    }
+
+    override fun onResume() {
+        super.onResume()
+        Timber.tag(AppConstants.TAG_TEL).i("$this onResume")
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        Timber.tag(AppConstants.TAG_TEL).i("$this onDestroy")
+    }
 }

--- a/app/src/main/java/app/TracingUtil.kt
+++ b/app/src/main/java/app/TracingUtil.kt
@@ -9,7 +9,7 @@ import timber.log.Timber
 
 object TracingUtil {
 
-    private val coldLaunchSpanStarted = Suppliers.memoize { startColdLaunchTracing() }
+    private val coldLaunchSpan = Suppliers.memoize { startColdLaunchTracing() }
 
     private fun startColdLaunchTracing(): Span {
         val coldLaunchStartSpan = OpenTelemetryUtil.tracer().spanBuilder(EventType.APP_COLD_LAUNCH_STARTED.eventName).startSpan()
@@ -43,7 +43,7 @@ object TracingUtil {
     }
 
     fun startUpSpan(): Span {
-        return coldLaunchSpanStarted.get()
+        return coldLaunchSpan.get()
     }
 
     fun endSpan() {
@@ -69,7 +69,6 @@ object TracingUtil {
         val coldLaunchStartedEvent = coldLaunchStartedEvent(coldLaunchUuid, coldLaunchTimeMs)
         coldLaunchEndedSpan.addEvent(EventType.APP_COLD_LAUNCH_ENDED.eventName, coldLaunchStartedEvent)
         Timber.tag(TAG_TEL).i("[manual]:Cold launch span ended:$coldLaunchEndedSpan")
-
     }
 
 


### PR DESCRIPTION

2024-04-24 14:14:53.693 17318-17318 System.out              com.example.hello_otel               I  logging:ColdLaunchModel generated :ColdLaunchModel(timeMs=1713993293693, coldLaunchId=ColdLaunchId(uuid=b93571d9-2f05-402d-849d-84851cb44088))
2024-04-24 14:14:53.693 17318-17318 System.out              com.example.hello_otel               I  logging:ColdLaunchModel accessed:ColdLaunchModel(timeMs=1713993293693, coldLaunchId=ColdLaunchId(uuid=b93571d9-2f05-402d-849d-84851cb44088))
2024-04-24 14:14:53.694 17318-17318 logging                 com.example.hello_otel               I  Demo App started
2024-04-24 14:14:53.781 17318-17318 logging                 com.example.hello_otel               I  [start]:explicit_trace_id:cfa33263ee69caee3f692d9c06c3d208,implicit_trace_id:cfa33263ee69caee3f692d9c06c3d208
2024-04-24 14:14:53.781 17318-17318 logging                 com.example.hello_otel               I  [start]:start_explicit_span_id:569607099dcbdec3
2024-04-24 14:14:53.782 17318-17318 logging                 com.example.hello_otel               I  [manual]:Cold launch span started:SdkSpan{traceId=cfa33263ee69caee3f692d9c06c3d208, spanId=569607099dcbdec3, parentSpanContext=ImmutableSpanContext{traceId=00000000000000000000000000000000, spanId=0000000000000000, traceFlags=00, traceState=ArrayBasedTraceState{entries=[]}, remote=false, valid=false}, name=cold_launch_started, kind=INTERNAL, attributes=AttributesMap{data={attr_cold_launch_id=b93571d9-2f05-402d-849d-84851cb44088, attr_launch_id_time_ms=1713993293693}, capacity=128, totalAddedValues=2}, status=ImmutableStatusData{statusCode=UNSET, description=}, totalRecordedEvents=1, totalRecordedLinks=0, startEpochNanos=1713993293780000000, endEpochNanos=0}
2024-04-24 14:14:54.361 17318-17318 logging                 com.example.hello_otel               I  [end]:explicit_trace_id:cfa33263ee69caee3f692d9c06c3d208,implicit_trace_id:00000000000000000000000000000000
2024-04-24 14:14:54.362 17318-17318 logging                 com.example.hello_otel               I  [end]:explicit_span_id:569607099dcbdec3
2024-04-24 14:14:54.362 17318-17318 logging                 com.example.hello_otel               I  [manual]:Cold launch span ended:SdkSpan{traceId=cfa33263ee69caee3f692d9c06c3d208, spanId=569607099dcbdec3, parentSpanContext=ImmutableSpanContext{traceId=00000000000000000000000000000000, spanId=0000000000000000, traceFlags=00, traceState=ArrayBasedTraceState{entries=[]}, remote=false, valid=false}, name=cold_launch_started, kind=INTERNAL, attributes=AttributesMap{data={attr_cold_launch_id=b93571d9-2f05-402d-849d-84851cb44088, attr_launch_id_time_ms=1713993293693}, capacity=128, totalAddedValues=4}, status=ImmutableStatusData{statusCode=UNSET, description=}, totalRecordedEvents=2, totalRecordedLinks=0, startEpochNanos=1713993293780000000, endEpochNanos=0}
2024-04-24 14:14:54.363 17318-17318 LoggingSpanExporter     com.example.hello_otel               I  'cold_launch_started' : cfa33263ee69caee3f692d9c06c3d208 569607099dcbdec3 INTERNAL [tracer: HelloOtel:0.0.1] AttributesMap{data={attr_cold_launch_id=b93571d9-2f05-402d-849d-84851cb44088, attr_launch_id_time_ms=1713993293693}, capacity=128, totalAddedValues=4}
2024-04-24 14:14:54.363 17318-17318 logging                 com.example.hello_otel               I  app.MainActivity@f57400a created
2024-04-24 14:16:43.038 17665-17665 System.out              com.example.hello_otel               I  logging:ColdLaunchModel generated :ColdLaunchModel(timeMs=1713993403037, coldLaunchId=ColdLaunchId(uuid=0a736e33-438c-4c2c-9531-c4246c444fe0))
2024-04-24 14:16:43.038 17665-17665 System.out              com.example.hello_otel               I  logging:ColdLaunchModel accessed:ColdLaunchModel(timeMs=1713993403037, coldLaunchId=ColdLaunchId(uuid=0a736e33-438c-4c2c-9531-c4246c444fe0))
2024-04-24 14:16:43.039 17665-17665 logging                 com.example.hello_otel               I  Demo App started
2024-04-24 14:16:43.117 17665-17665 logging                 com.example.hello_otel               I  [start]:explicit_trace_id:060c54bb7f39e1cb215fe233d5b32c03,implicit_trace_id:060c54bb7f39e1cb215fe233d5b32c03
2024-04-24 14:16:43.117 17665-17665 logging                 com.example.hello_otel               I  [start]:start_explicit_span_id:8d7db9361c96d25e
2024-04-24 14:16:43.118 17665-17665 logging                 com.example.hello_otel               I  [manual]:Cold launch span started:SdkSpan{traceId=060c54bb7f39e1cb215fe233d5b32c03, spanId=8d7db9361c96d25e, parentSpanContext=ImmutableSpanContext{traceId=00000000000000000000000000000000, spanId=0000000000000000, traceFlags=00, traceState=ArrayBasedTraceState{entries=[]}, remote=false, valid=false}, name=cold_launch_started, kind=INTERNAL, attributes=AttributesMap{data={attr_cold_launch_id=0a736e33-438c-4c2c-9531-c4246c444fe0, attr_launch_id_time_ms=1713993403037}, capacity=128, totalAddedValues=2}, status=ImmutableStatusData{statusCode=UNSET, description=}, totalRecordedEvents=1, totalRecordedLinks=0, startEpochNanos=1713993403116000000, endEpochNanos=0}
2024-04-24 14:16:43.700 17665-17665 logging                 com.example.hello_otel               I  [end]:explicit_trace_id:060c54bb7f39e1cb215fe233d5b32c03,implicit_trace_id:00000000000000000000000000000000
2024-04-24 14:16:43.700 17665-17665 logging                 com.example.hello_otel               I  [end]:explicit_span_id:8d7db9361c96d25e
2024-04-24 14:16:43.700 17665-17665 logging                 com.example.hello_otel               I  [manual]:Cold launch span ended:SdkSpan{traceId=060c54bb7f39e1cb215fe233d5b32c03, spanId=8d7db9361c96d25e, parentSpanContext=ImmutableSpanContext{traceId=00000000000000000000000000000000, spanId=0000000000000000, traceFlags=00, traceState=ArrayBasedTraceState{entries=[]}, remote=false, valid=false}, name=cold_launch_started, kind=INTERNAL, attributes=AttributesMap{data={attr_cold_launch_id=0a736e33-438c-4c2c-9531-c4246c444fe0, attr_launch_id_time_ms=1713993403037}, capacity=128, totalAddedValues=4}, status=ImmutableStatusData{statusCode=UNSET, description=}, totalRecordedEvents=2, totalRecordedLinks=0, startEpochNanos=1713993403116000000, endEpochNanos=0}
2024-04-24 14:16:43.701 17665-17665 LoggingSpanExporter     com.example.hello_otel               I  'cold_launch_started' : 060c54bb7f39e1cb215fe233d5b32c03 8d7db9361c96d25e INTERNAL [tracer: HelloOtel:0.0.1] AttributesMap{data={attr_cold_launch_id=0a736e33-438c-4c2c-9531-c4246c444fe0, attr_launch_id_time_ms=1713993403037}, capacity=128, totalAddedValues=4}
2024-04-24 14:16:43.701 17665-17665 logging                 com.example.hello_otel               I  app.MainActivity@f57400a onCreate
2024-04-24 14:16:43.757 17665-17665 logging                 com.example.hello_otel               I  app.MainActivity@f57400a onStart
2024-04-24 14:16:43.759 17665-17665 logging                 com.example.hello_otel               I  app.MainActivity@f57400a onResume




2024-04-24 14:16:51.300 17665-17665 logging                 com.example.hello_otel               I  app.MainActivity@f57400a onPause
2024-04-24 14:16:51.723 17665-17665 logging                 com.example.hello_otel               I  app.MainActivity@f57400a onStop
2024-04-24 14:16:54.191 17665-17665 logging                 com.example.hello_otel               I  app.MainActivity@f57400a onStart
2024-04-24 14:16:54.210 17665-17665 logging                 com.example.hello_otel               I  app.MainActivity@f57400a onResume


2024-04-24 14:17:39.806 17665-17665 logging                 com.example.hello_otel               I  app.MainActivity@f57400a onPause
2024-04-24 14:17:39.832 17665-17665 logging                 com.example.hello_otel               I  app.MainActivity@f57400a onStop
2024-04-24 14:17:42.136 17665-17665 logging                 com.example.hello_otel               I  app.MainActivity@f57400a onStart
2024-04-24 14:17:42.148 17665-17665 logging                 com.example.hello_otel               I  app.MainActivity@f57400a onResume
